### PR TITLE
Properly output unicode characters.

### DIFF
--- a/libraries/cms/response/json.php
+++ b/libraries/cms/response/json.php
@@ -115,6 +115,9 @@ class JResponseJson
 	 */
 	public function __toString()
 	{
+		if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+			return json_encode($this, JSON_UNESCAPED_UNICODE);
+		}
 		return json_encode($this);
 	}
 }


### PR DESCRIPTION
Added a check for the PHP (>= 5.4) version and `JSON_UNESCAPED_UNICODE` to the `return json_encode` statement of the `__toString` method to display the unicode characters properly.
